### PR TITLE
Pull Request Merge Event for Auto-Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,10 @@ name: Auto-publish Release
 
 # Event to only execute when a push on master branch has occured.
 on: 
-  push:
+  pull_request:
     branches: 
       - master
+    types: [closed]  
 
 jobs:
   build:
@@ -12,8 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      
     - name: Get the release version
+      if: github.event.pull_request.merged
       uses: cycjimmy/semantic-release-action@v2
       id: semantic 
       # Environment Variables


### PR DESCRIPTION
#### What does this PR do?
This changes the trigger to automatically generate release from `push` event into `pull_request` event and requires the event to have type of closed and merge flag.

#### Description of Task to be completed?
Closes #28 

#### How should this be manually tested?
Can be tested when merging into `master` branch