### PR TITLE
Adding the Confirm Modal for Delete functionalities and Fixes the Back button in Setitems page

### DIFF
--- a/src/ItemsStore.jsx
+++ b/src/ItemsStore.jsx
@@ -1,5 +1,4 @@
 import React, {createContext, useReducer} from 'react';
-import { logoWindows } from 'ionicons/icons';
 
 export const ItemsContext = createContext({});
 

--- a/src/pages/CrudCard.jsx
+++ b/src/pages/CrudCard.jsx
@@ -156,9 +156,7 @@ const Play = (props) => {
 			},
 			{
 				text: 'Okay',
-				handler: () => {
-					console.log('Confirm Okay');
-				}
+				handler: () => {deleteItem(id)}
 			}
 		]
 	}
@@ -207,7 +205,7 @@ const Play = (props) => {
 						</IonFabButton>
 						<IonFabButton style={{display: "inline-block", marginBottom: 20}}>
 							<IonIcon icon={trashBinOutline} onClick={() => {setPromptVisible(true)}} />
-							{/* onClick={() => {deleteItem(id)}} */}
+							{/* onClick={} */}
 						</IonFabButton>
 					</div>
 				</IonToolbar>

--- a/src/pages/CrudCard.jsx
+++ b/src/pages/CrudCard.jsx
@@ -13,6 +13,7 @@ const Play = (props) => {
 	const {dispatch} = useContext(ItemsContext);
 	const [flipped, setFlip] = useState(false);
 	const [isPromptVisible, setPromptVisible] = useState(false);
+	const [isAlertVisible, setAlertVisible] = useState(false);
 	const [frontCardText, setFrontCardText ] = useState(null);
 	const [backCardText, setBackCardText ] = useState(null);
 	const [toastState, setToastState] = useState({
@@ -111,8 +112,8 @@ const Play = (props) => {
 	}
 
 	const alertProps = {
-		isOpen: isPromptVisible,
-		onDidDismiss: () => setPromptVisible(false),
+		isOpen: isAlertVisible,
+		onDidDismiss: () => setAlertVisible(false),
 		header: (flipped) ? "Answer!" : "Question!",
 		inputs: [
 			{
@@ -126,7 +127,7 @@ const Play = (props) => {
 				text: 'Cancel',
 				role: 'cancel',
 				cssClass: 'secondary',
-				handler: () => setPromptVisible(false)
+				handler: () => setAlertVisible(false)
 			},
 			{
 				text: 'Ok',
@@ -135,8 +136,28 @@ const Play = (props) => {
 						setBackCardText(data.Answer);
 						return;
 					} 
-
 					setFrontCardText(data.Question);
+				}
+			}
+		]
+	}
+
+	const promptProps = {
+		isOpen: isPromptVisible,
+		onDidDismiss: () => setPromptVisible(false),
+		header: 'Delete Card',
+		message: 'Are you sure you want to remove this Card?',
+		buttons: [
+			{
+				text: 'Cancel',
+				role: 'cancel',
+				cssClass: 'secondary',
+				handler: () => setPromptVisible(false)
+			},
+			{
+				text: 'Okay',
+				handler: () => {
+					console.log('Confirm Okay');
 				}
 			}
 		]
@@ -158,7 +179,7 @@ const Play = (props) => {
 			</IonToolbar>
 			<div className="container" style={{ paddingTop: "8vh"}}>
 				<IonCard style={{height: "64vh", boxShadow: "none"}}>
-					<div className={"card" + (flipped ? " is-flipped" : "")} onClick={() => setPromptVisible(true)}>
+					<div className={"card" + (flipped ? " is-flipped" : "")} onClick={() => setAlertVisible(true)}>
 						<div className="card__face card__face--front">
 							<IonCardContent className="container">
 								<IonCardTitle>
@@ -169,8 +190,8 @@ const Play = (props) => {
 						<div className="card__face card__face--back">
 							<IonCardContent className="container">
 								<IonCardTitle>{(backCardText === null) ? <i>Put Answer!</i> : backCardText}</IonCardTitle>
-							</IonCardContent>	
-						</div>	
+							</IonCardContent>
+						</div>
 					</div>
 				</IonCard>
 				<IonToolbar>
@@ -185,14 +206,16 @@ const Play = (props) => {
 							<IonIcon icon={refreshOutline} />
 						</IonFabButton>
 						<IonFabButton style={{display: "inline-block", marginBottom: 20}}>
-							<IonIcon icon={trashBinOutline} onClick={() => {deleteItem(id)}} />
+							<IonIcon icon={trashBinOutline} onClick={() => {setPromptVisible(true)}} />
+							{/* onClick={() => {deleteItem(id)}} */}
 						</IonFabButton>
 					</div>
 				</IonToolbar>
 			</div>
 		</IonContent>
 		
-		<IonAlert {...alertProps} />
+		<IonAlert {...alertProps}/>
+		<IonAlert {...promptProps} />
 		<IonToast
 			isOpen={toastState.visible}
 			onDidDismiss={() => setToastState({visible: false, message: null})}

--- a/src/pages/SetItems.jsx
+++ b/src/pages/SetItems.jsx
@@ -22,7 +22,6 @@ import { ItemsContext } from "../ItemsStore";
 
 const { Storage } = Plugins;
 
-
 const Item = ({id, data}) => {
 	const history = useHistory();
 
@@ -73,10 +72,8 @@ const RenderItems = () => {
 	</>
 }
 
-
 const SetItems = () => {
 	const history = useHistory();
-	
 	const context = useContext(ItemsContext);
 
 	function deleteAllItems(context) {
@@ -95,8 +92,8 @@ const SetItems = () => {
 		<IonPage>
 			<IonContent scrollEvents={false}>
 				<IonToolbar style={{ marginTop: 10, paddingLeft: 10}}>
-					<IonButtons style={{display: "inline-block"}}>
-						<IonBackButton defaultHref="home" text="" icon={arrowBackOutline}/>
+					<IonButtons style={{display: "inline-block"}} onClick={() => history.push("/home")} >
+						<IonIcon icon={arrowBackOutline} style={{ fontSize: 30, color: "gray"}}/>
 					</IonButtons>
 					<div style={{display: "inline-block", marginLeft: 10, maxWidth: "85%"}}>
 						<IonCardTitle style={{fontSize: "1.2em"}}>Set of Cards</IonCardTitle>

--- a/src/pages/SetItems.jsx
+++ b/src/pages/SetItems.jsx
@@ -15,7 +15,7 @@ import {
 	IonAlert
 } from "@ionic/react";
 import React, {useState, useEffect, useContext} from "react";
-import {arrowBackOutline, addOutline, closeOutline, logoWindows} from 'ionicons/icons';
+import {arrowBackOutline, addOutline, closeOutline} from 'ionicons/icons';
 import { Plugins } from '@capacitor/core';
 import { useHistory } from "react-router-dom";
 import { ItemsContext } from "../ItemsStore";

--- a/src/pages/SetItems.jsx
+++ b/src/pages/SetItems.jsx
@@ -94,7 +94,7 @@ const SetItems = () => {
 	const promptProps = {
 		isOpen: isPromptVisible,
 		onDidDismiss: () => setPromptVisible(false),
-		header: 'Delete Card',
+		header: 'Clear Cards',
 		message: 'Are you sure you want to remove all Cards?',
 		buttons: [
 			{

--- a/src/pages/SetItems.jsx
+++ b/src/pages/SetItems.jsx
@@ -3,7 +3,6 @@ import {
 	IonPage,
 	IonToolbar,
 	IonButtons,
-	IonBackButton,
 	IonCardTitle,
 	IonCardSubtitle,
 	IonFabButton,
@@ -12,7 +11,8 @@ import {
 	IonCard,
 	IonRow,
 	IonCol,
-	IonGrid
+	IonGrid,
+	IonAlert
 } from "@ionic/react";
 import React, {useState, useEffect, useContext} from "react";
 import {arrowBackOutline, addOutline, closeOutline, logoWindows} from 'ionicons/icons';
@@ -72,9 +72,12 @@ const RenderItems = () => {
 	</>
 }
 
+
+
 const SetItems = () => {
 	const history = useHistory();
 	const context = useContext(ItemsContext);
+	const [isPromptVisible, setPromptVisible] = useState(false);
 
 	function deleteAllItems(context) {
 		const {dispatch} = context;
@@ -87,6 +90,26 @@ const SetItems = () => {
 		
 		dispatch({type: "SET_ITEMS", value: newItemsJson});
 	}
+
+	const promptProps = {
+		isOpen: isPromptVisible,
+		onDidDismiss: () => setPromptVisible(false),
+		header: 'Delete Card',
+		message: 'Are you sure you want to remove all Cards?',
+		buttons: [
+			{
+				text: 'Cancel',
+				role: 'cancel',
+				cssClass: 'secondary',
+				handler: () => setPromptVisible(false)
+			},
+			{
+				text: 'Okay',
+				handler: () => {deleteAllItems(context)}
+			}
+		]
+	}
+
 
 	return (
 		<IonPage>
@@ -109,14 +132,17 @@ const SetItems = () => {
 				</IonGrid>
 				<div style={{width: "70px", position: "fixed", bottom: 10, right: 10, textAlign: "right"}}>
 					<IonFabButton style={{display: "inline-block"}} color="danger">
-						<IonIcon icon={closeOutline} onClick={() => {deleteAllItems(context)}} />
+						<IonIcon icon={closeOutline} onClick={() => {setPromptVisible(true)}} />
 					</IonFabButton>
 					<IonFabButton style={{display: "inline-block"}} onClick={() => history.push("/crudCard")}>
 						<IonIcon icon={addOutline} />
 					</IonFabButton>
 				</div>
 			</IonContent>
+
+			<IonAlert {...promptProps} />
 		</IonPage>
+
 	);
 };
 export default SetItems;


### PR DESCRIPTION
#### What does this PR do?
**Feature:**
Adding the Confirmation modals on delete functionalities in SetItem and Crudcard pages. There should be a modal that prompts when user tap the delete button.
**Bug:**
Fixes the issue of the Back button in SetItems page.

#### Description of Task to be completed?
Closes #59 , #56 

#### How should this be manually tested?
No manual tested is required.


#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/37430183/78499191-d10d0780-7781-11ea-83c0-fdd32ecd34b2.png)
